### PR TITLE
feat: add plan output display to GitHub Actions logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ jobs:
 | parallelism         | Limit the number of concurrent operations (--parallelism=n).                | `10`        |
 | state               | Legacy option for local backend only (--state=STATEFILE).                   | `''`        |
 | show-sensitive      | Display sensitive values in output (--show-sensitive).                      | `false`     |
+| display-plan        | Display the plan output in the GitHub Actions log (true/false).             | `true`      |
 
 ## Outputs
 
@@ -153,6 +154,25 @@ steps:
     with:
       name: terraform-plan
       path: ./infra/tfplan
+```
+
+### Quiet Plan (No Output Display)
+```yaml
+steps:
+  - name: Checkout code
+    uses: actions/checkout@v4
+  
+  - name: Setup OpenTofu
+    uses: opentofu/setup-opentofu@v1
+    with:
+      tofu_version: '1.8.0'
+  
+  - name: Run Quiet Plan
+    uses: dnogu/tofu-plan@v1
+    with:
+      working-directory: ./infra
+      display-plan: false
+      out: "plan-output"
 ```
 
 ## Author

--- a/action.yml
+++ b/action.yml
@@ -105,6 +105,10 @@ inputs:
     description: 'Display sensitive values in output (--show-sensitive).'
     required: false
     default: 'false'
+  display-plan:
+    description: 'Display the plan output in the GitHub Actions log (true/false).'
+    required: false
+    default: 'true'
 outputs:
   plan-output:
     description: 'The output from tofu plan.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -103,7 +103,8 @@ async function run() {
       concise: core.getInput('concise'),
       parallelism: core.getInput('parallelism'),
       state: core.getInput('state'),
-      showSensitive: core.getInput('show-sensitive')
+      showSensitive: core.getInput('show-sensitive'),
+      displayPlan: core.getInput('display-plan')
     };
 
     const cmd = buildTofuPlanCommand(inputs);
@@ -122,8 +123,21 @@ async function run() {
       if (inputs.detailedExitcode === 'true' && (exitCode === 0 || exitCode === 2)) {
         core.info(`tofu plan completed with exit code ${exitCode}.`);
       } else if (exitCode !== 0) {
+        // Still show the output even if there's an error
+        if (output && inputs.displayPlan !== 'false') {
+          core.startGroup('📋 OpenTofu Plan Output (with errors)');
+          console.log(output);
+          core.endGroup();
+        }
         throw error;
       }
+    }
+    
+    // Print the plan output to the console for visibility
+    if (output && inputs.displayPlan !== 'false') {
+      core.startGroup('📋 OpenTofu Plan Output');
+      console.log(output);
+      core.endGroup();
     }
     
     core.setOutput('plan-output', output);

--- a/index.js
+++ b/index.js
@@ -97,7 +97,8 @@ async function run() {
       concise: core.getInput('concise'),
       parallelism: core.getInput('parallelism'),
       state: core.getInput('state'),
-      showSensitive: core.getInput('show-sensitive')
+      showSensitive: core.getInput('show-sensitive'),
+      displayPlan: core.getInput('display-plan')
     };
 
     const cmd = buildTofuPlanCommand(inputs);
@@ -116,8 +117,21 @@ async function run() {
       if (inputs.detailedExitcode === 'true' && (exitCode === 0 || exitCode === 2)) {
         core.info(`tofu plan completed with exit code ${exitCode}.`);
       } else if (exitCode !== 0) {
+        // Still show the output even if there's an error
+        if (output && inputs.displayPlan !== 'false') {
+          core.startGroup('📋 OpenTofu Plan Output (with errors)');
+          console.log(output);
+          core.endGroup();
+        }
         throw error;
       }
+    }
+    
+    // Print the plan output to the console for visibility
+    if (output && inputs.displayPlan !== 'false') {
+      core.startGroup('📋 OpenTofu Plan Output');
+      console.log(output);
+      core.endGroup();
     }
     
     core.setOutput('plan-output', output);


### PR DESCRIPTION
- Add display-plan input option (default: true) to control output visibility
- Display plan output in a collapsible group in GitHub Actions logs
- Show output even when plans have errors or non-zero exit codes
- Add documentation and examples for the new display-plan feature
- Preserve plan output in action outputs for downstream use

This allows users to see the OpenTofu plan results directly in the GitHub Actions log without needing to enable debug mode, while still providing the option to disable output display for quiet mode.

